### PR TITLE
Remove debug directory prints

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -22,11 +22,6 @@ import tempfile
 import shutil
 import os
 from pathlib import Path
-
-print("=== FILES IN CURRENT DIR ===")
-for file in Path(".").glob("*"):
-    print(file)
-print("============================")
 from urllib.parse import urlparse
 from typing import Optional, Tuple
 


### PR DESCRIPTION
## Summary
- remove leftover debug prints that listed current directory contents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869609df6cc8331af7a7b94a35e60ad