### PR TITLE
Handle malformed URLs

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -151,7 +151,8 @@ def is_supported_url(url: str) -> bool:
         if "youtube.com" in host or "youtu.be" in host:
             return "/shorts/" in path or "v=" in parsed.query or "youtu.be" in host
         return False
-    except Exception:
+    except (ValueError, TypeError, AttributeError) as e:
+        log.warning(f"Invalid URL format: {url}, error: {e}")
         return False
 
 


### PR DESCRIPTION
## Summary
- log invalid URLs instead of silencing all exceptions
- test warnings for malformed URLs
- verify that unexpected exceptions still propagate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686acda67bb483318e7cf36ae5cf0b74