### PR TITLE
Fix status message formatting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -452,7 +452,7 @@ async def cmd_status(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     uid = update.effective_user.id
     used = get_quota_usage(uid)
     if uid == OWNER_ID:
-        text = "👑 Вы владелец бота \- лимитов нет"
+        text = "👑 Вы владелец бота - лимитов нет"
     else:
         text = f"Использовано: {used}/{FREE_LIMIT}"
     await update.message.reply_text(text)


### PR DESCRIPTION
## Summary
- avoid stray backslash when owner checks `/status`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b02016a38833191c48b3605017631